### PR TITLE
join + fmap = bind

### DIFF
--- a/src/Streaming/Internal.hs
+++ b/src/Streaming/Internal.hs
@@ -603,8 +603,8 @@ concats :: (Monad m, Functor f) => Stream (Stream f m) m r -> Stream f m r
 concats  = loop where
   loop stream = case stream of
     Return r -> return r
-    Effect m  -> join $ lift (liftM loop m)
-    Step fs  -> join (fmap loop fs)
+    Effect m  -> lift m >>= loop
+    Step fs  -> fs >>= loop
 {-# INLINE concats #-}
 
 {-| Split a succession of layers after some number, returning a streaming or

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -632,8 +632,8 @@ delay seconds = loop where
 > takeWhile' thus = S.drained . S.span thus
 
 -}
-drained :: (Monad m, Monad (t m), Functor (t m), MonadTrans t) => t m (Stream (Of a) m r) -> t m r
-drained = join . fmap (lift . effects)
+drained :: (Monad m, Monad (t m), MonadTrans t) => t m (Stream (Of a) m r) -> t m r
+drained tms = tms >>= lift . effects
 {-#INLINE drained #-}
 
 -- ---------------


### PR DESCRIPTION
Original PR text from @treeowl:

> It's simpler, and very often faster, to use `m >>= f` instead of `join (fmap f m)`.