### PR TITLE
Add differently-constrained maps and mapped

### DIFF
--- a/src/Streaming.hs
+++ b/src/Streaming.hs
@@ -19,8 +19,12 @@ module Streaming
 
    -- * Transforming streams
    maps,
+   mapsPost,
    mapsM,
+   mapsMPost,
    mapped,
+   mappedPost,
+   hoistUnexposed,
    distribute,
    groups,
 

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -96,7 +96,9 @@ module Streaming.Prelude (
     , map
     , mapM
     , maps
+    , mapsPost
     , mapped
+    , mappedPost
     , for
     , with
     , subst
@@ -1352,6 +1354,14 @@ mapped :: (Monad m, Functor f) => (forall x . f x -> m (g x)) -> Stream f m r ->
 mapped = mapsM
 {-#INLINE mapped #-}
 
+{-| A version of 'mapped' that imposes a 'Functor' constraint on the target functor rather
+    than the source functor. This version should be preferred if 'fmap' on the target
+    functor is cheaper.
+
+-}
+mappedPost :: (Monad m, Functor g) => (forall x . f x -> m (g x)) -> Stream f m r -> Stream g m r
+mappedPost = mapsMPost
+{-# INLINE mappedPost #-}
 
 {-| Fold streamed items into their monoidal sum
 


### PR DESCRIPTION
Sometimes, the target functor of `maps` or `mapped` offers
a more efficient `fmap` than the source functor. Add versions
of `maps`, `mapped`, and `mapsM` that use that one instead.

Add explicitly "unsafe" `hoistUnexposed` and `hoistUnexposed2`.
Add "safe" `hoistUnexposed`.