### PR TITLE
Deprecate mapsExposed and mapsMExposed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
     Made `zipsWith` and allied functions short-circuit; if the
     first stream is empty, ignore the second one.
 
+    Deprecated `mapsExposed` and `mapsMExposed`. These were perfectly
+    safe copies of `maps` and `mapsM` with scary names.
+
 - 0.1.3.0 
 
     Added `duplicate` and `store` for simultaneous folding.

--- a/src/Streaming/Internal.hs
+++ b/src/Streaming/Internal.hs
@@ -837,20 +837,16 @@ hoistExposedPost trans = loop where
     Step f -> Step (fmap loop f)
 {-# INLINABLE hoistExposedPost #-}
 
+{-# DEPRECATED mapsExposed "Use maps instead." #-}
 mapsExposed :: (Monad m, Functor f)
      => (forall x . f x -> g x) -> Stream f m r -> Stream g m r
-mapsExposed phi = loop where
-  loop stream = case stream of
-    Return r  -> Return r
-    Effect m   -> Effect (liftM loop m)
-    Step f    -> Step (phi (fmap loop f))
+mapsExposed = maps
 {-# INLINABLE mapsExposed #-}
 
-mapsMExposed phi = loop where
-  loop stream = case stream of
-    Return r  -> Return r
-    Effect m   -> Effect (liftM loop m)
-    Step f    -> Effect (liftM Step (phi (fmap loop f)))
+{-# DEPRECATED mapsMExposed "Use mapsM instead." #-}
+mapsMExposed :: (Monad m, Functor f)
+     => (forall x . f x -> m (g x)) -> Stream f m r -> Stream g m r
+mapsMExposed = mapsM
 {-# INLINABLE mapsMExposed #-}
 
 {-| Map a stream directly to its church encoding; compare @Data.List.foldr@


### PR DESCRIPTION
`mapsExposed` was just a copy of `maps`, and `mapsMExposed` was just
a copy of `mapsM`. As far as I can tell, neither of them does anything
that exposes the abstraction, so there's no point in having these
scarily-named versions.

Fixes #7