### PR TITLE
Add and improve instances

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,17 @@
     Deprecated `mapsExposed` and `mapsMExposed`. These were perfectly
     safe copies of `maps` and `mapsM` with scary names.
 
+    Made the `Show` and `Eq` instances for `Stream` respect the
+    abstraction. In effect, the streams are `unexposed` before
+    being shown or tested for equality.
+
+    Added `Eq1`, `Ord`, `Ord1`, and `Show1` instances for `Stream`.
+
+    Added `Generic`, `Generic1`, `Eq1`, `Ord1`, `Show1`, `Eq2`, `Ord2`,
+    and `Show2` instances for `Of`.
+
+    Bump the lower bound on `transformers` to 0.5.
+
 - 0.1.3.0 
 
     Added `duplicate` and `store` for simultaneous folding.

--- a/streaming.cabal
+++ b/streaming.cabal
@@ -214,7 +214,7 @@ library
   build-depends:       base >=4.6 && <5
                      , mtl >=2.1 && <2.3
                      , mmorph >=1.0 && <1.1
-                     , transformers >=0.4 && <0.6
+                     , transformers >=0.5 && <0.6
                      , transformers-base < 0.5
                      , resourcet > 1.1.0 && < 1.2
                      , exceptions > 0.5 && < 0.9


### PR DESCRIPTION
Made the `Show` and `Eq` instances for `Stream` respect the
abstraction. In effect, the streams are `unexposed` before
being shown or tested for equality.

Added `Eq1`, `Ord`, `Ord1`, and `Show1` instances for `Stream`.

Added `Generic`, `Generic1`, `Eq1`, `Ord1`, `Show1`, `Eq2`, `Ord2`,
and `Show2` instances for `Of`.

Fixes #3