### PR TITLE
Add changelog.md to extra-source-files

### DIFF
--- a/streaming.cabal
+++ b/streaming.cabal
@@ -191,7 +191,7 @@ stability:           Experimental
 homepage:            https://github.com/haskell-streaming/streaming
 bug-reports:         https://github.com/haskell-streaming/streaming/issues
 category:            Data, Pipes, Streaming
-extra-source-files:  README.md
+extra-source-files:  README.md, changelog.md
 
 source-repository head
     type: git


### PR DESCRIPTION
Currently, the changelog isn't bundled with the source distribution, which prevents the changelog from being displayed on Hackage. This adds `changelog.md` to `extra-source-files` to correct this.