### PR TITLE
Fix build with 7.10.3 and fix doctests

### DIFF
--- a/src/Data/Functor/Of.hs
+++ b/src/Data/Functor/Of.hs
@@ -36,7 +36,7 @@ instance (Monoid a, Monoid b) => Monoid (Of a b) where
 instance Functor (Of a) where
   fmap f (a :> x) = a :> f x
   {-#INLINE fmap #-}
-  a <$ (b :> x)   = b :> a
+  a <$ (b :> _)   = b :> a
   {-#INLINE (<$) #-}
 
 #if MIN_VERSION_base(4,8,0)
@@ -52,19 +52,19 @@ instance Bifunctor Of where
 instance Monoid a => Applicative (Of a) where
   pure x = mempty :> x
   {-#INLINE pure #-}
-  m :> f <*> m' :> x = mappend m m' :> f x
+  (m :> f) <*> (m' :> x) = mappend m m' :> f x
   {-#INLINE (<*>) #-}
-  m :> x *> m' :> y  = mappend m m' :> y
+  (m :> _) *> (m' :> y)  = mappend m m' :> y
   {-#INLINE (*>) #-}
-  m :> x <* m' :> y  = mappend m m' :> x
+  (m :> x) <* (m' :> _)  = mappend m m' :> x
   {-#INLINE (<*) #-}
 
 instance Monoid a => Monad (Of a) where
-  return x = mempty :> x
+  return = pure
   {-#INLINE return #-}
-  m :> x >> m' :> y = mappend m m' :> y
+  (m :> _) >> (m' :> y) = mappend m m' :> y
   {-#INLINE (>>) #-}
-  m :> x >>= f = let m' :> y = f x in mappend m m' :> y
+  (m :> x) >>= f = let m' :> y = f x in mappend m m' :> y
   {-#INLINE (>>=) #-}
 
 #if MIN_VERSION_base(4,9,0)

--- a/src/Data/Functor/Of.hs
+++ b/src/Data/Functor/Of.hs
@@ -6,9 +6,7 @@ import Data.Semigroup (Semigroup (..))
 import Control.Applicative
 import Data.Traversable (Traversable)
 import Data.Foldable (Foldable)
-#if MIN_VERSION_base(4,8,0)
 import Data.Bifunctor
-#endif
 import Data.Data
 import Data.Typeable
 import GHC.Generics (Generic, Generic1)

--- a/src/Streaming.hs
+++ b/src/Streaming.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
 
-{-# OPTIONS_GHC -Wall #-}
 module Streaming
    (
    -- * An iterable streaming monad transformer

--- a/src/Streaming.hs
+++ b/src/Streaming.hs
@@ -115,10 +115,10 @@ import Data.Bifunctor
     Some of these are quite abstract and pervade any use of the library,
     e.g.
 
->   maps ::    (forall x . f x -> g x)     -> Stream f m r -> Stream g m r
->   mapped ::  (forall x . f x -> m (g x)) -> Stream f m r -> Stream g m r
->   hoist ::   (forall x . m x -> n x)     -> Stream f m r -> Stream f n r -- from the MFunctor instance
->   concats :: Stream (Stream f m) m r -> Stream f m r   
+>   maps    :: (forall x . f x -> g x)     -> Stream f m r -> Stream g m r
+>   mapped  :: (forall x . f x -> m (g x)) -> Stream f m r -> Stream g m r
+>   hoist   :: (forall x . m x -> n x)     -> Stream f m r -> Stream f n r -- from the MFunctor instance
+>   concats :: Stream (Stream f m) m r     -> Stream f m r
 
     (assuming here and thoughout that @m@ or @n@ satisfies a @Monad@ constraint, and
     @f@ or @g@ a @Functor@ constraint.)
@@ -128,9 +128,9 @@ import Data.Bifunctor
 >   chunksOf     :: Int -> Stream f m r -> Stream (Stream f m) m r
 >   splitsAt     :: Int -> Stream f m r -> Stream f m (Stream f m r)
 >   zipsWith     :: (forall x y. f x -> g y -> h (x, y))
-                 -> Stream f m r -> Stream g m r -> Stream h m r
+>                -> Stream f m r -> Stream g m r -> Stream h m r
 >   zipsWith'    :: (forall x y p. (x -> y -> p) -> f x -> g y -> h p)
-                 -> Stream f m r -> Stream g m r -> Stream h m r
+>                -> Stream f m r -> Stream g m r -> Stream h m r
 >   intercalates :: Stream f m () -> Stream (Stream f m) m r -> Stream f m r
 >   unzips       :: Stream (Compose f g) m r ->  Stream f (Stream g m) r
 >   separate     :: Stream (Sum f g) m r -> Stream f (Stream g) m r  -- cp. partitionEithers

--- a/src/Streaming/Internal.hs
+++ b/src/Streaming/Internal.hs
@@ -6,10 +6,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -Wall #-}
 module Streaming.Internal (
     -- * The free monad transformer
     -- $stream
@@ -1360,4 +1358,4 @@ cutoff = loop where
       e <- lift $ inspect str
       case e of
         Left r -> return (Just r)
-        Right (frest) -> Step $ fmap (loop (n-1)) frest
+        Right frest -> Step $ fmap (loop (n-1)) frest

--- a/src/Streaming/Internal.hs
+++ b/src/Streaming/Internal.hs
@@ -99,6 +99,9 @@ import Data.Functor.Sum
 import Data.Monoid (Monoid (..))
 import Data.Semigroup (Semigroup (..))
 
+-- $setup
+-- >>> import Streaming.Prelude as S
+
 {- $stream
 
     The 'Stream' data type is equivalent to @FreeT@ and can represent any effectful

--- a/src/Streaming/Internal.hs
+++ b/src/Streaming/Internal.hs
@@ -1,12 +1,11 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module Streaming.Internal (
     -- * The free monad transformer

--- a/src/Streaming/Internal.hs
+++ b/src/Streaming/Internal.hs
@@ -98,7 +98,6 @@ import Data.Functor.Compose
 import Data.Functor.Sum
 import Data.Monoid (Monoid (..))
 import Data.Semigroup (Semigroup (..))
-import Prelude hiding (splitAt)
 
 {- $stream
 

--- a/src/Streaming/Internal.hs
+++ b/src/Streaming/Internal.hs
@@ -971,9 +971,9 @@ zipsWith' phi = loop
     loop :: Stream f m r -> Stream g m r -> Stream h m r
     loop s t = case s of
        Return r -> Return r
-       Step fs -> case t of
+       Step fs  -> case t of
          Return r -> Return r
-         Step gs -> Step $ phi loop fs gs
+         Step gs  -> Step $ phi loop fs gs
          Effect n -> Effect $ fmap (loop s) n
        Effect m -> Effect $ fmap (flip loop t) m
 {-# INLINABLE zipsWith' #-}
@@ -1038,7 +1038,7 @@ separate odd_even
 
     Now, for example, it is convenient to fold on the left and right values separately:
 
->>>  S.toList $ S.toList $ separate odd_even
+>>> S.toList $ S.toList $ separate odd_even
 [2,4,6,8,10] :> ([1,3,5,7,9] :> ())
 
 

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -47,15 +47,11 @@
 > --------------------------------------------------------------------------------------------------------------------
 >
 -}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 module Streaming.Prelude (
     -- * Types

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -57,8 +57,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
-{-# OPTIONS_GHC -Wall #-}
-
 module Streaming.Prelude (
     -- * Types
     Of (..)

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -1117,7 +1117,7 @@ for :: (Monad m, Functor f) => Stream (Of a) m r -> (a -> Stream f m x) -> Strea
 for str0 act = loop str0 where
   loop str = case str of
     Return r         -> Return r
-    Effect m          -> Effect $ fmap loop m
+    Effect m         -> Effect $ fmap loop m
     Step (a :> rest) -> act a *> loop rest
 {-# INLINABLE for #-}
 
@@ -1329,7 +1329,7 @@ mapM :: Monad m => (a -> m b) -> Stream (Of a) m r -> Stream (Of b) m r
 mapM f = loop where
   loop str = case str of
     Return r       -> Return r
-    Effect m        -> Effect (fmap loop m)
+    Effect m       -> Effect (fmap loop m)
     Step (a :> as) -> Effect $ do
       a' <- f a
       return (Step (a' :> loop as) )

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -1265,7 +1265,7 @@ last_ = loop Nothing_ where
 -}
 length_ :: Monad m => Stream (Of a) m r -> m Int
 length_ = fold_ (\n _ -> n + 1) 0 id
-{-# INLINE length_#-}
+{-# INLINE length_ #-}
 
 {-| Run a stream, keeping its length and its return value.
 

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -8,7 +8,7 @@
     articulated in the latter two modules. Because we dispense with piping and
     conduiting, the distinction between all of these modules collapses. Some things are
     lost but much is gained: on the one hand, everything comes much closer to ordinary
-    beginning Haskell programming and, on the other, acquires the plasticity of programming 
+    beginning Haskell programming and, on the other, acquires the plasticity of programming
     directly with a general free monad type. The leading type, @Stream (Of a) m r@ is chosen to permit an api
     that is as close as possible to that of @Data.List@ and the @Prelude@.
 
@@ -64,7 +64,7 @@ module Streaming.Prelude (
     , stdinLn
     , readLn
     , fromHandle
-    , readFile 
+    , readFile
     , iterate
     , iterateM
     , repeat
@@ -76,7 +76,7 @@ module Streaming.Prelude (
     , enumFrom
     , enumFromThen
     , unfoldr
-    
+
 
 
     -- * Consuming streams of elements
@@ -86,7 +86,7 @@ module Streaming.Prelude (
     , mapM_
     , print
     , toHandle
-    , writeFile 
+    , writeFile
     , effects
     , erase
     , drained
@@ -229,7 +229,7 @@ module Streaming.Prelude (
     , merge
     , mergeOn
     , mergeBy
-    
+
     -- * Maybes
     -- $maybes
     , catMaybes
@@ -878,7 +878,7 @@ filter thePred = loop where
       else loop as
 {-# INLINE filter #-}  -- ~ 10% faster than INLINABLE in simple bench
 
-                         
+
 -- ---------------
 -- filterM
 -- ---------------
@@ -1709,7 +1709,7 @@ reread step s = loop where
       Just a  -> return (Step (a :> loop))
 {-# INLINABLE reread #-}
 
-{-| Strict left scan, streaming, e.g. successive partial results. The seed 
+{-| Strict left scan, streaming, e.g. successive partial results. The seed
     is yielded first, before any action of finding the next element is performed.
 
 
@@ -1731,13 +1731,13 @@ reread step s = loop where
 -}
 scan :: Monad m => (x -> a -> x) -> x -> (x -> b) -> Stream (Of a) m r -> Stream (Of b) m r
 scan step begin done str = Step (done begin :> loop begin str)
-  where                   
+  where
   loop !acc stream = do
     case stream of
       Return r -> Return r
       Effect m -> Effect (fmap (loop acc) m)
-      Step (a :> rest) -> 
-        let !acc' = step acc a 
+      Step (a :> rest) ->
+        let !acc' = step acc a
         in Step (done acc' :> loop acc' rest)
 {-# INLINABLE scan #-}
 
@@ -1758,7 +1758,7 @@ scanM :: Monad m => (x -> a -> m x) -> m x -> (x -> m b) -> Stream (Of a) m r ->
 scanM step begin done str = Effect $ do
     x <- begin
     b <- done x
-    return (Step (b :> loop x str))  
+    return (Step (b :> loop x str))
   where
     loop !x stream = case stream of -- note we have already yielded from x
       Return r -> Return r
@@ -2055,7 +2055,7 @@ toList_ = fold_ (\diff a ls -> diff (a: ls)) id (\diff -> diff [])
 
 >  mapped toList :: Stream (Stream (Of a)) m r -> Stream (Of [a]) m
 
-    Like 'toList_', 'toList' breaks streaming; unlike 'toList_' it /preserves the return value/ 
+    Like 'toList_', 'toList' breaks streaming; unlike 'toList_' it /preserves the return value/
     and thus is frequently useful with e.g. 'mapped'
 
 >>> S.print $ mapped S.toList $ chunksOf 3 $ each [1..9]
@@ -2068,7 +2068,7 @@ t<Enter>
 ["s","t"]
 u<Enter>
 v<Enter>
-["u","v"] 
+["u","v"]
 -}
 toList :: Monad m => Stream (Of a) m r -> m (Of [a] r)
 toList = fold (\diff a ls -> diff (a: ls)) id (\diff -> diff [])
@@ -2300,7 +2300,7 @@ stdinLn = fromHandle IO.stdin
 -}
 
 readLn :: (MonadIO m, Read a) => Stream (Of a) m ()
-readLn = loop where 
+readLn = loop where
   loop = do
     eof <- liftIO IO.isEOF
     unless eof $ do
@@ -2846,7 +2846,7 @@ mergeBy cmp = loop
           LT -> Step (a :> loop rest0 str1)
           EQ -> Step (a :> loop rest0 str1) -- left-biased
           GT -> Step (b :> loop str0 rest1)
-{-# INLINABLE mergeBy #-}        
+{-# INLINABLE mergeBy #-}
 
 {- $maybes
     These functions discard the 'Nothing's that they encounter. They are analogous
@@ -2855,7 +2855,7 @@ mergeBy cmp = loop
 
 {-| The 'catMaybes' function takes a 'Stream' of 'Maybe's and returns
     a 'Stream' of all of the 'Just' values. 'concat' has the same behavior,
-    but is more general; it works for any foldable container type. 
+    but is more general; it works for any foldable container type.
 -}
 catMaybes :: Monad m => Stream (Of (Maybe a)) m r -> Stream (Of a) m r
 catMaybes = loop where
@@ -2870,7 +2870,7 @@ catMaybes = loop where
 {-| The 'mapMaybe' function is a version of 'map' which can throw out elements. In particular,
     the functional argument returns something of type @'Maybe' b@. If this is 'Nothing', no element
     is added on to the result 'Stream'. If it is @'Just' b@, then @b@ is included in the result 'Stream'.
-    
+
 -}
 mapMaybe :: Monad m => (a -> Maybe b) -> Stream (Of a) m r -> Stream (Of b) m r
 mapMaybe phi = loop where
@@ -2882,9 +2882,9 @@ mapMaybe phi = loop where
       Just b -> Step (b :> loop snext)
 {-# INLINABLE mapMaybe #-}
 
-{-| 'slidingWindow' accumulates the first @n@ elements of a stream, 
+{-| 'slidingWindow' accumulates the first @n@ elements of a stream,
      update thereafter to form a sliding window of length @n@.
-     It follows the behavior of the slidingWindow function in 
+     It follows the behavior of the slidingWindow function in
      <https://hackage.haskell.org/package/conduit-combinators-1.0.4/docs/Data-Conduit-Combinators.html#v:slidingWindow conduit-combinators>.
 
 >>> S.print $ slidingWindow 4 $ S.each "123456"
@@ -2894,25 +2894,25 @@ fromList "3456"
 
 -}
 
-slidingWindow :: Monad m 
-  => Int 
-  -> Stream (Of a) m b 
+slidingWindow :: Monad m
+  => Int
+  -> Stream (Of a) m b
   -> Stream (Of (Seq.Seq a)) m b
-slidingWindow n = setup (max 1 n :: Int) mempty 
-  where 
-    window !sequ str = do 
-      e <- lift (next str) 
-      case e of 
+slidingWindow n = setup (max 1 n :: Int) mempty
+  where
+    window !sequ str = do
+      e <- lift (next str)
+      case e of
         Left r -> return r
-        Right (a,rest) -> do 
+        Right (a,rest) -> do
           yield (sequ Seq.|> a)
           window (Seq.drop 1 $ sequ Seq.|> a) rest
     setup 0 !sequ str = do
-       yield sequ 
-       window (Seq.drop 1 sequ) str 
-    setup m sequ str = do 
-      e <- lift $ next str 
-      case e of 
+       yield sequ
+       window (Seq.drop 1 sequ) str
+    setup m sequ str = do
+      e <- lift $ next str
+      case e of
         Left r ->  yield sequ >> return r
         Right (x,rest) -> setup (m-1) (sequ Seq.|> x) rest
 {-# INLINABLE slidingWindow #-}

--- a/streaming.cabal
+++ b/streaming.cabal
@@ -186,13 +186,13 @@ description:         This package contains two modules, <http://hackage.haskell.
 license:             BSD3
 license-file:        LICENSE
 author:              michaelt
-maintainer:          andrew.thaddeus@gmail.com, what_is_it_to_do_anything@yahoo.com
+maintainer:          andrew.thaddeus@gmail.com, chessai1996@gmail.com
 stability:           Experimental
 homepage:            https://github.com/haskell-streaming/streaming
 bug-reports:         https://github.com/haskell-streaming/streaming/issues
 category:            Data, Pipes, Streaming
 extra-source-files:  README.md, changelog.md
-tested-with:         GHC ==7.10.3, GHC ==8.0.2, GHC ==8.2.2
+tested-with:         GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.2
 
 source-repository head
     type: git
@@ -213,13 +213,7 @@ library
     , transformers-base < 0.5
     , ghc-prim
     , containers
-  hs-source-dirs:    src
-  default-language:  Haskell2010
-  ghc-options:
-    -Wall
-    -fwarn-name-shadowing
-  if impl(ghc >= 8.0)
-    ghc-options:
-      -Wincomplete-uni-patterns
-      -Wincomplete-record-updates
-      -Wcompat
+  hs-source-dirs:
+    src
+  default-language:
+    Haskell2010

--- a/streaming.cabal
+++ b/streaming.cabal
@@ -4,13 +4,13 @@ cabal-version:       >=1.10
 build-type:          Simple
 synopsis:            an elementary streaming prelude and general stream type.
 
-description:         This package contains two modules, <http://hackage.haskell.org/package/streaming/docs/Streaming.html Streaming> 
+description:         This package contains two modules, <http://hackage.haskell.org/package/streaming/docs/Streaming.html Streaming>
                      and <http://hackage.haskell.org/package/streaming/docs/Streaming-Prelude.html Streaming.Prelude>.
                      The principal module, <http://hackage.haskell.org/package/streaming-0.1.4.3/docs/Streaming-Prelude.html Streaming.Prelude>, exports an elementary streaming prelude focused on
                      a simple \"source\" or \"producer\" type, namely @Stream (Of a) m r@.
                      This is a sort of effectful version of
                      @([a],r)@ in which successive elements of type @a@ arise from some sort of monadic
-                     action before the succession ends with a value of type @r@. 
+                     action before the succession ends with a value of type @r@.
                      Everything in the library is organized to make
                      programming with this type as simple as possible,
                      by the simple expedient of making it as close to @Prelude@
@@ -21,11 +21,11 @@ description:         This package contains two modules, <http://hackage.haskell.
                      > 1<Enter>
                      > 2<Enter>
                      > 3<Enter>
-                     > 6 :> () 
+                     > 6 :> ()
                      .
                      sums the first three valid integers from user input. Similarly,
                      .
-                     > >>> S.stdoutLn $ S.map (map toUpper) $ S.take 2 S.stdinLn 
+                     > >>> S.stdoutLn $ S.map (map toUpper) $ S.take 2 S.stdinLn
                      > hello<Enter>
                      > HELLO
                      > world!<Enter>
@@ -33,13 +33,13 @@ description:         This package contains two modules, <http://hackage.haskell.
                      .
                      upper-cases the first two lines from stdin as they arise,
                      and sends them to stdout. And so on,
-                     with filtering, mapping, breaking, chunking, zipping, unzipping, replicating 
-                     and so forth: 
+                     with filtering, mapping, breaking, chunking, zipping, unzipping, replicating
+                     and so forth:
                      we program with streams of @Int@s or @String@s directly as
                      if they constituted something like a list. That's because streams really do constitute something
-                     like a list, and the associated operations can mostly have the same names. 
-                     (A few, like @reverse@, don't stream and thus disappear; 
-                     others like @unzip@ are here given properly streaming formulation for the first time.) 
+                     like a list, and the associated operations can mostly have the same names.
+                     (A few, like @reverse@, don't stream and thus disappear;
+                     others like @unzip@ are here given properly streaming formulation for the first time.)
                      And we everywhere
                      oppose \"extracting a pure list from IO\",
                      which is the origin of typical Haskell memory catastrophes.
@@ -53,7 +53,7 @@ description:         This package contains two modules, <http://hackage.haskell.
                      .
                      > main = mapM newIORef [1..10^8::Int] >>= mapM readIORef >>= mapM_ print
                      .
-                     The new user notices that this exhausts memory, and worries about the efficiency of Haskell @IORefs@. 
+                     The new user notices that this exhausts memory, and worries about the efficiency of Haskell @IORefs@.
                      But of course it exhausts memory! Look what it says!
                      The problem is immediately cured by writing
                      .
@@ -100,7 +100,7 @@ description:         This package contains two modules, <http://hackage.haskell.
                      elementary streaming library - since one possesses @Stream ((,) a) m r@
                      or equivalently @Stream (Of a) m r@. This
                      is the type of a \'generator\' or \'producer\' or \'source\' or whatever
-                     you call an effectful stream of items. 
+                     you call an effectful stream of items.
                      /The present Streaming.Prelude is thus the simplest streaming library that can replicate anything like the API of the Prelude and Data.List/.
                      .
                      The emphasis of the library is on interoperation; for
@@ -117,7 +117,7 @@ description:         This package contains two modules, <http://hackage.haskell.
                      a complex framework, but in a way that integrates transparently with
                      the rest of Haskell, using ideas - e.g. rank 2 types, which are here
                      implicit or explicit in most mapping - that the user can carry elsewhere,
-                     rather than chaining her understanding to the curiosities of 
+                     rather than chaining her understanding to the curiosities of
                      a so-called streaming IO framework (as necessary as that is for certain purposes.)
                      .
                      See the

--- a/streaming.cabal
+++ b/streaming.cabal
@@ -218,7 +218,7 @@ library
     , mtl >=2.1 && <2.3
     , mmorph >=1.0 && <1.2
     , semigroups >= 0.18 && <0.19
-    , transformers >=0.5 && <0.6
+    , transformers >=0.4 && <0.6
     , transformers-base < 0.5
     , ghc-prim
     , containers

--- a/streaming.cabal
+++ b/streaming.cabal
@@ -192,6 +192,7 @@ homepage:            https://github.com/haskell-streaming/streaming
 bug-reports:         https://github.com/haskell-streaming/streaming/issues
 category:            Data, Pipes, Streaming
 extra-source-files:  README.md, changelog.md
+tested-with:         GHC ==7.10.3, GHC ==8.0.2, GHC ==8.2.2
 
 source-repository head
     type: git
@@ -203,16 +204,6 @@ library
     , Streaming.Prelude
     , Streaming.Internal
     , Data.Functor.Of
-  other-extensions:
-      RankNTypes
-    , CPP
-    , StandaloneDeriving
-    , FlexibleContexts
-    , DeriveDataTypeable
-    , DeriveFoldable
-    , DeriveFunctor
-    , DeriveTraversable
-    , UndecidableInstances
   build-depends:
       base >=4.8 && <5
     , mtl >=2.1 && <2.3
@@ -224,3 +215,11 @@ library
     , containers
   hs-source-dirs:    src
   default-language:  Haskell2010
+  ghc-options:
+    -Wall
+    -fwarn-name-shadowing
+  if impl(ghc >= 8.0)
+    ghc-options:
+      -Wincomplete-uni-patterns
+      -Wincomplete-record-updates
+      -Wcompat


### PR DESCRIPTION
I noticed a couple of things that can stand some improvements, so I applied a few (hopefully uncontroversial) improvements. I also noticed that there's no test suite except doctests, so I tried to run doctest on the package but that basically failed. I tried to fix doctests but the package is still left in a condition where it's not possible to just run doctests on it and expects the process to complete.

The problem with doctests is that many doctests read from `stdin` and there's no way to specify custom stdin for doctests yet (some tests specify stdin contents interleaved with stdout contents, which will be even harder to specify for the tool). I tried disabling those and fix the rest but the disabling changed how haddock documentation looks. So I fixed all doctest issues I encountered in tests that do not use stdin or external files and restored tests as before - so do take care if you try to run doctests yourself.

Regarding build with `7.10.3` it's not clear whether this package should build with it - the constraint on `base` permits `7.10.3` but constraint on `transformers` doesn't. It seems easy to at least make it build with 7.10.3, yet my attempt looses `Eq1`, `Ord1` and `Show1` instances for that version. That's because those classes changed interface between `7.10.3` and `8.0.2` and I'm somewhat lazy.