### PR TITLE
Add Semigroup instances for Of and Stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-*
 cabal-dev
 *.o
 *.hi
@@ -15,3 +16,7 @@ cabal.sandbox.config
 *.aux
 *.hp
 *.stack-work
+cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 - ???
 
+    Add `Semigroup` instances for `Of` and `Stream`.
+
     Drop unneeded dependency on exceptions.
 
 - 0.2.0.0

--- a/src/Data/Functor/Of.hs
+++ b/src/Data/Functor/Of.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP, DeriveDataTypeable, DeriveTraversable, DeriveFoldable,
        DeriveGeneric #-}
 module Data.Functor.Of where
-import Data.Monoid
+import Data.Monoid (Monoid (..))
 import Data.Semigroup (Semigroup (..))
 import Control.Applicative
 import Data.Traversable (Traversable)

--- a/src/Data/Functor/Of.hs
+++ b/src/Data/Functor/Of.hs
@@ -2,6 +2,7 @@
        DeriveGeneric #-}
 module Data.Functor.Of where
 import Data.Monoid
+import Data.Semigroup (Semigroup (..))
 import Control.Applicative
 import Data.Traversable (Traversable)
 import Data.Foldable (Foldable)
@@ -19,11 +20,17 @@ data Of a b = !a :> b
               Read, Show, Traversable, Typeable, Generic, Generic1)
 infixr 5 :>
 
+instance (Semigroup a, Semigroup b) => Semigroup (Of a b) where
+  (m :> w) <> (m' :> w') = (m <> m') :> (w <> w')
+  {-#INLINE (<>) #-}
+
 instance (Monoid a, Monoid b) => Monoid (Of a b) where
   mempty = mempty :> mempty
   {-#INLINE mempty #-}
+#if !(MIN_VERSION_base(4,11,0))
   mappend (m :> w) (m' :> w') = mappend m m' :> mappend w w'
   {-#INLINE mappend #-}
+#endif
 
 instance Functor (Of a) where
   fmap f (a :> x) = a :> f x

--- a/streaming.cabal
+++ b/streaming.cabal
@@ -217,6 +217,7 @@ library
       base >=4.8 && <5
     , mtl >=2.1 && <2.3
     , mmorph >=1.0 && <1.2
+    , semigroups >= 0.18 && <0.19
     , transformers >=0.5 && <0.6
     , transformers-base < 0.5
     , ghc-prim


### PR DESCRIPTION
Currently, `streaming-0.2.0.0` fails to build on GHC 8.4.1 since `Semigroup` has become a superclass of `Monoid`, and `Of` and `Stream` lack `Semigroup` instances. This fixes the issue.

I opted to avoid some CPP by depending on the `semigroups` package to provide the `Semigroup` class on GHC 7.10 (before `Semigroup` was added to `base`). If you'd prefer to avoid incurring an extra dependency, I could alternatively remove the `semigroups` dependency and only define the `Semigroup` instances on `base-4.9` or later (at the cost of some CPP).
  