### PR TITLE
Add Hackage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-streaming
-=========
+# streaming [![Hackage version](https://img.shields.io/hackage/v/streaming.svg?label=Hackage)](https://hackage.haskell.org/package/streaming)
 
 Contents
 --------


### PR DESCRIPTION
Seems like a good idea to have a highly visible link to the Hackage package at the top and we might as well use a "proper" badge with a version number.