### PR TITLE
Add nubOrd, nubInt, nubOrdOn, nubIntOn.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+- 0.2.2.0
+
+    Added `nubOrd` and friends.
+
 - 0.2.1.0
 
     Adding `Semigroup` instances for GHC 8.4.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-- 0.2.2.0
+- ???
 
     Added `nubOrd` and friends.
 

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -1479,11 +1479,7 @@ nubOrd = nubOrdOn id
 
 {-|  Use 'nubOrdOn' to have a custom ordering function for your elements. -}
 nubOrdOn :: (Monad m, Ord b) => (a -> b) -> Stream (Of a) m r -> Stream (Of a) m r
-nubOrdOn f = \xs -> nubOrdOnExcluding f mempty xs
-{-# INLINE nubOrdOn #-}
-
-nubOrdOnExcluding :: (Monad m, Ord b) => (a -> b) -> Set.Set b -> Stream (Of a) m r -> Stream (Of a) m r
-nubOrdOnExcluding f = loop where
+nubOrdOn f xs = loop mempty xs where
   loop !set stream = case stream of
     Return r         -> Return r
     Effect m         -> Effect (liftM (loop set) m)
@@ -1499,11 +1495,7 @@ nubInt = nubIntOn id
 {-# INLINE nubInt #-}
 
 nubIntOn :: Monad m => (a -> Int) -> Stream (Of a) m r -> Stream (Of a) m r
-nubIntOn f = \xs -> nubIntOnExcluding f mempty xs
-{-# INLINE nubIntOn #-}
-
-nubIntOnExcluding :: Monad m => (a -> Int) -> IntSet.IntSet -> Stream (Of a) m r -> Stream (Of a) m r
-nubIntOnExcluding f = loop where
+nubIntOn f xs = loop mempty xs where
   loop !set stream = case stream of
     Return r         -> Return r
     Effect m         -> Effect (liftM (loop set) m)

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -112,6 +112,10 @@ module Streaming.Prelude (
     , store
     , chain
     , sequence
+    , nubOrd
+    , nubOrdOn
+    , nubInt
+    , nubIntOn
     , filter
     , filterM
     , mapMaybeM
@@ -270,6 +274,8 @@ import Data.Monoid (Monoid (mappend, mempty))
 import Control.Concurrent (threadDelay)
 import Data.Functor.Compose
 import Data.Functor.Of
+import qualified Data.Set as Set
+import qualified Data.IntSet as IntSet
 
 -- instance (Eq a) => Eq1 (Of a) where eq1 = (==)
 -- instance (Ord a) => Ord1 (Of a) where compare1 = compare
@@ -525,7 +531,7 @@ chain f = loop where
       return (Step (a :> loop rest))
 {-# INLINABLE chain #-}
 
-{-| Make a stream of traversable containers into a stream of their separate elements.
+{-| Make a stream of foldable containers into a stream of their separate elements.
     This is just
 
 > concat str = for str each
@@ -1452,6 +1458,59 @@ notElem_ a' = loop True where
         then return False
         else loop True rest
 {-#INLINABLE notElem_ #-}
+
+
+{-| Remove repeated elements from a Stream. 'nubOrd' of course accumulates a 'Data.Set.Set' of
+    elements that have already been seen and should thus be used with care.
+
+>>> S.toList_ $ S.nubOrd $ S.take 5 S.readLn :: IO ([Int])
+1<Enter>
+2<Enter>
+3<Enter>
+1<Enter>
+2<Enter>
+[1,2,3]
+
+-}
+
+nubOrd :: (Monad m, Ord a) => Stream (Of a) m r -> Stream (Of a) m r
+nubOrd = nubOrdOn id
+{-# INLINE nubOrd #-}
+
+{-|  Use 'nubOrdOn' to have a custom ordering function for your elements. -}
+nubOrdOn :: (Monad m, Ord b) => (a -> b) -> Stream (Of a) m r -> Stream (Of a) m r
+nubOrdOn f = \xs -> nubOrdOnExcluding f mempty xs
+{-# INLINE nubOrdOn #-}
+
+nubOrdOnExcluding :: (Monad m, Ord b) => (a -> b) -> Set.Set b -> Stream (Of a) m r -> Stream (Of a) m r
+nubOrdOnExcluding f = loop where
+  loop !set stream = case stream of
+    Return r         -> Return r
+    Effect m         -> Effect (liftM (loop set) m)
+    Step (a :> rest) -> let !fa = f a in
+      if Set.member fa set
+         then loop set rest
+         else Step (a :> loop (Set.insert fa set) rest)
+
+{-| More efficient versions of above when working with 'Int's that use 'Data.IntSet.IntSet'. -}
+
+nubInt :: Monad m => Stream (Of Int) m r -> Stream (Of Int) m r
+nubInt = nubIntOn id
+{-# INLINE nubInt #-}
+
+nubIntOn :: Monad m => (a -> Int) -> Stream (Of a) m r -> Stream (Of a) m r
+nubIntOn f = \xs -> nubIntOnExcluding f mempty xs
+{-# INLINE nubIntOn #-}
+
+nubIntOnExcluding :: Monad m => (a -> Int) -> IntSet.IntSet -> Stream (Of a) m r -> Stream (Of a) m r
+nubIntOnExcluding f = loop where
+  loop !set stream = case stream of
+    Return r         -> Return r
+    Effect m         -> Effect (liftM (loop set) m)
+    Step (a :> rest) -> let !fa = f a in
+      if IntSet.member fa set
+         then loop set rest
+         else Step (a :> loop (IntSet.insert fa set) rest)
 
 
 {-|
@@ -2481,7 +2540,7 @@ sumToCompose x = case x of
     like 'MonadResource'.  Thus I can independently filter and write to one file, but
     nub and write to another, or interact with a database and a logfile and the like:
 
->>> runResourceT $ (S.writeFile "hello2.txt" . S.nub) $ store (S.writeFile "hello.txt" . S.filter (/= "world")) $ each ["hello", "world", "goodbye", "world"]
+>>> runResourceT $ (S.writeFile "hello2.txt" . S.nubOrd) $ store (S.writeFile "hello.txt" . S.filter (/= "world")) $ each ["hello", "world", "goodbye", "world"]
 >>> :! cat hello.txt
 hello
 goodbye

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-04-14
+resolver: lts-11.5
 packages:
 - '.'
 extra-deps: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2017-12-09
+resolver: nightly-2018-04-13
 packages:
 - '.'
 extra-deps: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-04-13
+resolver: nightly-2018-04-14
 packages:
 - '.'
 extra-deps: []

--- a/streaming.cabal
+++ b/streaming.cabal
@@ -1,5 +1,5 @@
 name:                streaming
-version:             0.2.1.0
+version:             0.2.2.0
 cabal-version:       >=1.10
 build-type:          Simple
 synopsis:            an elementary streaming prelude and general stream type.

--- a/streaming.cabal
+++ b/streaming.cabal
@@ -1,5 +1,5 @@
 name:                streaming
-version:             0.2.2.0
+version:             0.2.1.0
 cabal-version:       >=1.10
 build-type:          Simple
 synopsis:            an elementary streaming prelude and general stream type.


### PR DESCRIPTION
Closes #43.

*  We might also add `nub`, `nubBy`, `nubOn` for types with only `Eq`, but I didn't attempt it.  I suppose they'd be pretty inefficient unless the stream is mostly duplicates (but that is a valid use case).

*  Per discussion, I followed the naming conventions from `containers`, rather than the previous naming.  Although, I noticed [`Control.Foldl`](https://hackage.haskell.org/package/foldl-1.3.7/docs/Control-Foldl.html#v:nub) uses a "reverse" convention (`nub` for the `Ord` instance, `eqNub` for `Eq`-only).

*  The code and documentation are largely based on (or outright copied from) `nub` from the past version of `streaming`.

*  Unrelated docs fix (traversable -> foldable).

*  There is some code repetition between the `Ord` and `Int` versions.  Possibly these could be factored and specialized.

*  Fusion rules are above my pay grade, so I didn't try to re-engineer the ones in `containers`.  Thus there may be room for optimization there.