### PR TITLE
Fixes performance problem with S.concat

### DIFF
--- a/src/Streaming/Internal.hs
+++ b/src/Streaming/Internal.hs
@@ -231,12 +231,8 @@ instance (Functor f, Monad m) => Functor (Stream f m) where
 instance (Functor f, Monad m) => Monad (Stream f m) where
   return = Return
   {-# INLINE return #-}
-  stream1 >> stream2 = loop stream1 where
-    loop stream = case stream of
-      Return _ -> stream2
-      Effect m  -> Effect (fmap loop m)
-      Step f   -> Step (fmap loop f)  
-  {-# INLINABLE (>>) #-}
+  (>>) = (*>)
+  {-# INLINE (>>) #-}
   -- (>>=) = _bind
   -- {-#INLINE (>>=) #-}
   --
@@ -281,6 +277,13 @@ instance (Functor f, Monad m) => Applicative (Stream f m) where
   {-# INLINE pure #-}
   streamf <*> streamx = do {f <- streamf; x <- streamx; return (f x)} 
   {-# INLINE (<*>) #-}  
+  stream1 *> stream2 = loop stream1 where
+    loop stream = case stream of
+      Return _ -> stream2
+      Effect m  -> Effect (fmap loop m)
+      Step f   -> Step (fmap loop f)
+  {-# INLINABLE (*>) #-}
+
 
 {- | The 'Alternative' instance glues streams together stepwise.
 


### PR DESCRIPTION
Fixes #47.

The default `*>` implementation causes the `S.for` not to be tail recursive. This should be tested against base == 4.8, I'm not 100% sure this is backwards compatibile.