### PR TITLE
Only depend on semigroups on old GHCs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,8 @@
     
     Provide a MonadFail instance for Stream.
 
+    Only depend on `semigroups` on old GHCs.
+
 - 0.2.1.0
 
     Adding `Semigroup` instances for GHC 8.4.

--- a/streaming.cabal
+++ b/streaming.cabal
@@ -208,14 +208,15 @@ library
       base >=4.8 && <5
     , mtl >=2.1 && <2.3
     , mmorph >=1.0 && <1.2
-    , semigroups >= 0.18 && <0.19
     , transformers >=0.4 && <0.6
     , transformers-base < 0.5
     , ghc-prim
     , containers
 
   if !impl(ghc >= 8.0)
-    build-depends: fail        == 4.9.*
+    build-depends:
+        fail == 4.9.*
+      , semigroups >= 0.18 && <0.19
 
   hs-source-dirs:
     src


### PR DESCRIPTION
The conditional was already there for `fail`. It makes sense to only
incur the dependency on compatibility packages when needed, so let's
add `semigroups` to the conditional set, instead of depending on it unconditionally.